### PR TITLE
Add account id to wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,5 @@
 name = "single-spa-foundry-worker"
+account_id = '4e3c47217c0159e8dfb0da2f736bf59f'
 type = "webpack"
 route = ''
 zone_id = ''


### PR DESCRIPTION
We are adding the account_id to the wrangler.toml file, which is required by Cloudflare.