### PR TITLE
Package via trailing slash

### DIFF
--- a/src/handleImportMap.test.ts
+++ b/src/handleImportMap.test.ts
@@ -22,6 +22,35 @@ describe(`handleImportMap`, () => {
     expect(await response.json()).toEqual(importMap);
   });
 
+  it(`returns a valid import map, with packages via trailing slashes`, async () => {
+    const importMap: ImportMap = {
+      imports: {
+        react: "https://cdn.single-spa-foundry.com/react.js",
+      },
+      scopes: {},
+    };
+
+    const importMapPackagesViaTrailingSlashes: ImportMap = {
+      imports: {
+        react: "https://cdn.single-spa-foundry.com/react.js",
+        "react/": "https://cdn.single-spa-foundry.com/",
+      },
+      scopes: {},
+    };
+
+    (global.MAIN_KV as MockCloudflareKV).mockKv({
+      "import-map-juc-system": importMap,
+    });
+    const request = new Request("https://cdn.example.com/systemjs.importmap");
+    const response: Response = await handleImportMap(request, {
+      importMapName: "system",
+      orgKey: "juc",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importMapPackagesViaTrailingSlashes);
+  });
+
   it(`returns a 404 Not Found if the map isn't in KV`, async () => {
     (global.MAIN_KV as MockCloudflareKV).mockKv({});
 

--- a/src/handleImportMap.test.ts
+++ b/src/handleImportMap.test.ts
@@ -5,7 +5,7 @@ describe(`handleImportMap`, () => {
   it(`returns a valid import map`, async () => {
     const importMap: ImportMap = {
       imports: {
-        react: "/react.js",
+        react: "https://cdn.single-spa-foundry.com/react.js",
       },
       scopes: {},
     };
@@ -72,7 +72,7 @@ describe(`handleImportMap`, () => {
     (global.MAIN_KV as MockCloudflareKV).mockKv({
       "import-map-juc-system": {
         imports: {
-          react: "/react.js",
+          react: "https://cdn.single-spa-foundry.com/react.js",
         },
         // strings are invalid values for "scopes"
         scopes: "asdfsafd",
@@ -91,7 +91,7 @@ describe(`handleImportMap`, () => {
     (global.MAIN_KV as MockCloudflareKV).mockKv({
       "import-map-juc-system": {
         imports: {
-          react: "/react.js",
+          react: "https://cdn.single-spa-foundry.com/react.js",
         },
         scopes: {
           "/hi/": {

--- a/src/handleImportMap.ts
+++ b/src/handleImportMap.ts
@@ -26,6 +26,8 @@ export async function handleImportMap(
       console.error(importMapErrors);
       return internalErrorResponse();
     } else {
+      addPackagesViaTrailingSlashes(importMap);
+
       return new Response(JSON.stringify(importMap, null, 2), {
         status: 200,
         headers: {
@@ -104,6 +106,17 @@ function verifyModuleMap(moduleMap: ModuleMap, path: string): string[] {
   }
 
   return errors;
+}
+
+function addPackagesViaTrailingSlashes(importMap: ImportMap) {
+  for (let importSpecifier in importMap.imports) {
+    if (!importSpecifier.endsWith("/")) {
+      importMap.imports[importSpecifier + "/"] = new URL(
+        ".",
+        importMap.imports[importSpecifier]
+      ).href;
+    }
+  }
 }
 
 interface Params {


### PR DESCRIPTION
This PR adds the function `addPackagesViaTrailingSlashes` to `handleImportMap()` allowing us to return the import map with packages via trailing slashes.  Test included to check for valid import map that returns with trailing slashes correctly.

Tests were modified to include the full url value, changing `react: "/react.js"` to `react: "https://cdn.single-spa-foundry.com/react.js"`.