### PR TITLE
Foundry environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "src/single-spa-foundry-worker.js",
   "scripts": {
-    "start": "wrangler dev",
+    "start": "wrangler dev --env dev",
+    "start:prod": "wrangler dev",
+    "start:test": "wrangler dev --env test",
     "prepare": "husky install",
     "lint": "eslint \"src/**/*\"",
     "format": "prettier --write .",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,1 +1,2 @@
 declare var MAIN_KV: KVNamespace;
+declare var FOUNDRY_ENV: string;

--- a/src/handleImportMap.ts
+++ b/src/handleImportMap.ts
@@ -55,6 +55,7 @@ async function readImportMap({
     // if KV has invalid JSON in it or is down
     console.error(`Error reading import map with key ${kvKey}`);
     console.error(err);
+    console.error(err?.message);
     return null;
   }
 }

--- a/src/handleImportMap.ts
+++ b/src/handleImportMap.ts
@@ -55,7 +55,7 @@ async function readImportMap({
     // if KV has invalid JSON in it or is down
     console.error(`Error reading import map with key ${kvKey}`);
     console.error(err);
-    console.error(err?.message);
+    console.error(err ? err.message : err);
     return null;
   }
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,99 @@
+import { handleRequest, updateRouteMatchers } from "./main";
+import { MockCloudflareKV } from "./setupTests";
+import { ImportMap } from "./handleImportMap";
+
+describe("main handle request", () => {
+  it("has correct route handlers for prod FOUNDRY_ENV", async () => {
+    global.FOUNDRY_ENV = "prod";
+    updateRouteMatchers();
+
+    const importMap: ImportMap = {
+      imports: {},
+      scopes: {},
+    };
+
+    (global.MAIN_KV as MockCloudflareKV).mockKv({
+      "import-map-walmart-systemjs": importMap,
+    });
+
+    let response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importMap);
+
+    response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/stage/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("has correct route handlers for test FOUNDRY_ENV", async () => {
+    global.FOUNDRY_ENV = "test";
+    updateRouteMatchers();
+
+    const importMap: ImportMap = {
+      imports: {},
+      scopes: {},
+    };
+
+    (global.MAIN_KV as MockCloudflareKV).mockKv({
+      "import-map-walmart-systemjs": importMap,
+    });
+
+    let response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(404);
+
+    response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/stage/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importMap);
+  });
+
+  it("has correct route handlers for dev FOUNDRY_ENV", async () => {
+    global.FOUNDRY_ENV = "dev";
+    updateRouteMatchers();
+
+    const importMap: ImportMap = {
+      imports: {},
+      scopes: {},
+    };
+
+    (global.MAIN_KV as MockCloudflareKV).mockKv({
+      "import-map-walmart-systemjs": importMap,
+    });
+
+    let response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importMap);
+
+    response = await handleRequest(
+      new Request(
+        "https://cdn.single-spa-foundry.com/walmart/stage/systemjs.importmap"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importMap);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -7,6 +7,7 @@ import { merge } from "lodash-es";
 let mocks = {};
 
 global.FOUNDRY_ENV = "prod";
+global.FOUNDRY_MFE_HOST = "https://example.com/";
 
 beforeEach(() => {
   global.FOUNDRY_MFE_HOST = "https://cdn.single-spa-foundry.com/apps/";
@@ -40,6 +41,7 @@ beforeEach(() => {
 
   global.MAIN_KV = mainKv;
   global.FOUNDRY_ENV = "prod";
+  global.FOUNDRY_MFE_HOST = "https://example.com/";
 });
 
 export interface MockCloudflareKV {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,8 @@ import "isomorphic-fetch";
 import { jest } from "@jest/globals";
 import { OrgSettings } from "./getOrgSettings";
 
+global.FOUNDRY_ENV = "prod";
+
 beforeEach(() => {
   const mainKv: MockCloudflareKV = {
     get: jest.fn(),
@@ -28,6 +30,7 @@ beforeEach(() => {
   };
 
   global.MAIN_KV = mainKv;
+  global.FOUNDRY_ENV = "prod";
 });
 
 export interface MockCloudflareKV {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,9 +11,20 @@ webpack_config = "webpack.config.cjs"
 kv_namespaces = [ 
   { binding = "MAIN_KV", preview_id = "e494f429e91b43b09a28fb2473ccdebe", id= "e494f429e91b43b09a28fb2473ccdebe" },
 ]
+
 [vars]
 FOUNDRY_ENV = "prod"
+
+[env.dev]
+kv_namespaces = [ 
+  { binding = "MAIN_KV", preview_id = "e494f429e91b43b09a28fb2473ccdebe", id= "e494f429e91b43b09a28fb2473ccdebe" },
+]
 [env.dev.vars]
 FOUNDRY_ENV = "dev"
+
+[env.test]
+kv_namespaces = [ 
+  { binding = "MAIN_KV", preview_id = "e494f429e91b43b09a28fb2473ccdebe", id= "e494f429e91b43b09a28fb2473ccdebe" },
+]
 [env.test.vars]
 FOUNDRY_ENV = "test"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,3 +11,9 @@ webpack_config = "webpack.config.cjs"
 kv_namespaces = [ 
   { binding = "MAIN_KV", preview_id = "e494f429e91b43b09a28fb2473ccdebe", id= "e494f429e91b43b09a28fb2473ccdebe" },
 ]
+[vars]
+FOUNDRY_ENV = "prod"
+[env.dev.vars]
+FOUNDRY_ENV = "dev"
+[env.test.vars]
+FOUNDRY_ENV = "test"


### PR DESCRIPTION
This PR makes it so the import map renders depending on the environment.
For example:

The **prod** environment
should work here: http://127.0.0.1:8787/walmart/systemjs.importmap
but not here: http://127.0.0.1:8787/walmart/bogus/systemjs.importmap

The **test** environment
should work here: http://127.0.0.1:8787/walmart/bogus/systemjs.importmap
but not here: http://127.0.0.1:8787/walmart/systemjs.importmap

The **dev** environment
should work here: http://127.0.0.1:8787/walmart/bogus/systemjs.importmap
and here: http://127.0.0.1:8787/walmart/systemjs.importmap
