### PR TITLE
Fix a couple small issues

### DIFF
--- a/src/handleApps.ts
+++ b/src/handleApps.ts
@@ -27,15 +27,16 @@ export async function handleApps(
 
   const proxyResponse = await fetch(proxyRequest);
 
+  const finalResponse = new Response(proxyResponse.body, proxyResponse);
   const additionalHeaders = corsHeaders(request, orgSettings);
   for (let additionalHeader in additionalHeaders) {
-    proxyResponse.headers.append(
+    finalResponse.headers.append(
       additionalHeader,
       additionalHeaders[additionalHeader]
     );
   }
 
-  return proxyResponse;
+  return finalResponse;
 }
 
 function getMicrofrontendProxySettings(

--- a/src/startupChecks.ts
+++ b/src/startupChecks.ts
@@ -1,4 +1,4 @@
-const requiredEnvVariables = ["FOUNDRY_MFE_HOST"];
+const requiredEnvVariables = ["FOUNDRY_MFE_HOST", "FOUNDRY_ENV"];
 
 export function startupChecks() {
   requiredEnvVariables.forEach((envVarName) => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,6 +24,8 @@ kv_namespaces = [
 ]
 [env.dev.vars]
 FOUNDRY_ENV = "dev"
+# TODO: swap this to be a bucket/server that's actually for foundry. This is just a placeholder
+FOUNDRY_MFE_HOST = "https://react.microfrontends.app/"
 
 [env.test]
 kv_namespaces = [ 
@@ -31,3 +33,5 @@ kv_namespaces = [
 ]
 [env.test.vars]
 FOUNDRY_ENV = "test"
+# TODO: swap this to be a bucket/server that's actually for foundry. This is just a placeholder
+FOUNDRY_MFE_HOST = "https://react.microfrontends.app/"


### PR DESCRIPTION
env vars in the wrangler.toml were changed in both #15 and #20 in ways that were incompatible with each other. In #15, the FOUNDRY_MFE_HOST env variable was introduced and given a default value. In #20, we made it so each env has its own set of env variables and didn't add FOUNDRY_MFE_HOST to that list. This fixes that.

Additionally, this fixes an issue I accidentally introduced in #15 related to cors headers for static files.