### PR TITLE
Deploy to environments

### DIFF
--- a/.github/workflows/build_deploy.yaml
+++ b/.github/workflows/build_deploy.yaml
@@ -15,7 +15,7 @@ jobs:
           node-version: "16"
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.9.1
+          version: 6.32.2
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm test
@@ -29,9 +29,14 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.32.2
+      - run: pnpm install --frozen-lockfile
       - name: Publish
         uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: ${{ secrets.CF_ENV }}
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
I've created github environments to match our cloudflare environments, and have set it up so we should be able to deploy to dev/test/prod

They are available at the following domains

https://dev.single-spa-foundry.workers.dev/
https://test.single-spa-foundry.workers.dev/
https://cdn.single-spa-foundry.workers.dev/

Right now they're not actually behaving correctly because they don't have the correct FOUNDRY_ENV set and aren't using the correct KV bindings. But once we deploy them via wrangler inside of github actions they should be good.